### PR TITLE
Increase line length to match IDE - 120

### DIFF
--- a/pep8speaks.yml
+++ b/pep8speaks.yml
@@ -1,0 +1,40 @@
+scanner:
+    diff_only: True  # If False, the entire file touched by the Pull Request is scanned for errors. If True, only the diff is scanned.
+    linter: pycodestyle  # Alternative option - flake8
+
+pycodestyle:  # Valid if scanner.linter is pycodestyle
+    max-line-length: 120
+    ignore: []  # Errors and warnings to ignore
+    exclude: []  # File path patterns to exclude
+    count: False
+    first: False
+    show-pep8: False
+    show-source: False
+    statistics: False
+    hang-closing: False
+    filename: []
+    select: []
+
+flake8:  # Valid if scanner.linter is flake8
+    max-line-length: 79
+    ignore: []
+    exclude: []
+    count: False
+    show-source: False
+    statistics: False
+    hang-closing: False
+    filename: []
+    select: []
+
+no_blank_comment: False  # If True, no comment is made on PR without any errors.
+descending_issues_order: False  # If True, PEP 8 issues in message will be displayed in descending order of line numbers in the file
+only_mention_files_with_errors: True  # If False, a separate status section for each file is made in the comment.
+
+message:  # Customize the comment made by the bot
+    opened:  # Messages when a new PR is submitted
+        header: ""
+        footer: ""
+    updated:  # Messages when a PR is updated
+        header: ""
+        footer: ""
+    no_errors: "There are currently no PEP 8 issues detected in this Pull Request. Cheers! :beers: "


### PR DESCRIPTION
Add a pep8speaks config file and set the line length error limit to 120, matching PyCharm.